### PR TITLE
25071037 puppet address_object addrconf link id validation are wholly incorrect

### DIFF
--- a/lib/puppet/type/address_object.rb
+++ b/lib/puppet/type/address_object.rb
@@ -103,16 +103,16 @@ Puppet::Type.newtype(:address_object) do
         desc "Specifies the local interface ID to be used for generating
               auto-configured addresses.  Only valid with an address_type of
               'addrconf'"
-        # addr obj is something like <interface>/v4<optional string>
-        newvalues(/\A\p{Alnum}+\/v[46](?:\p{Alpha}{0,})?\Z/)
+        # interface id is a 64-bit hex identifier like xxxx:xxxx:xxxx:xxxx
+        newvalues(/\h\h\h\h:\h\h\h\h:\h\h\h\h:\h\h\h\h/)
     end
 
     newproperty(:remote_interface_id) do
         desc "Specifies an optional remote interface ID to be used for
               generating auto-configured addresses.  Only valid with an
               address_type of 'addrconf'"
-        # addr obj is something like <interface>/v4<optional string>
-        newvalues(/\A\p{Alnum}+\/v[46](?:\p{Alpha}{0,})?\Z/)
+        # interface id is a 64-bit hex identifier like xxxx:xxxx:xxxx:xxxx
+        newvalues(/\h\h\h\h:\h\h\h\h:\h\h\h\h:\h\h\h\h/)
     end
 
     newproperty(:stateful) do

--- a/spec/unit/provider/address_object/address_object_spec.rb
+++ b/spec/unit/provider/address_object/address_object_spec.rb
@@ -40,8 +40,8 @@ describe Puppet::Type.type(:address_object).provider(:address_object) do
       [:down,:true,%w(-d)],
       [:seconds,"10",%w(-w 10)],
       [:hostname,"foo",%w(-h foo)],
-      [:interface_id,"lo0/v4",%w(-i local=lo0/v4)],
-      [:remote_interface_id,"lo0/v4",%w(-i remote=lo0/v4)],
+      [:interface_id,"1234:5678:90ab:cdef",%w(-i local=1234:5678:90ab:cdef)],
+      [:remote_interface_id,"1234:5678:90ab:cdef",%w(-i remote=1234:5678:90ab:cdef)],
       [:stateful,"yes",%w(-p stateful=yes)],
       [:stateless,"no",%w(-p stateless=no)]
     ].each { |arr|


### PR DESCRIPTION
Changed interface_id and remote_interface_id to use 64-bit hex identifiers in the form of xxxx:xxxx:xxxx:xxxx.
Updated existing spec tests.  Added spec tests to test rejection of an invalid value for these fields.

Signed-off-by: Patrick Einheber <patrick.einheber@oracle.com>