### PR TITLE
19429313,19888183,22125767,22072780 various

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@
    
 
 ###  Bugs Fixes and Enhancements:
+* 19888183 publisher provider is applied on each puppet run
+* 22072780 pkg_publisher provider applies 'searchfirst' every time
+* 22125767 nsswitch provider missing ipnodes, protocols
 * 23593308 rspec tests need to be written for solaris_providers ipmp_interface
 * 24696809 Puppet link aggregation modules cascading errors
 * 24836004 '-' is valid in pkg mediator implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,10 +90,12 @@
    
 
 ###  Bugs Fixes and Enhancements:
+* 19429313 address_object type should support vrrp addresses
 * 19888183 publisher provider is applied on each puppet run
 * 22072780 pkg_publisher provider applies 'searchfirst' every time
 * 22125767 nsswitch provider missing ipnodes, protocols
 * 23593308 rspec tests need to be written for solaris_providers ipmp_interface
+* 23593316 rspec tests need to be written for solaris_providers protocol_properties
 * 24696809 Puppet link aggregation modules cascading errors
 * 24836004 '-' is valid in pkg mediator implementation
 * 24836209 nis provider needs to support multiple securenets entries
@@ -113,9 +115,8 @@
 * 25177901 puppet beadm should not use both -e and -p
 * 25178928 puppet link_aggregation should try to copy existing values on change of mode
 * 25179040 puppet link_aggregation should delete with -t for temporary
-* 25192742 puppet svccfg shouldn't try to update properties for a non-existent fmri
-* 23593316 rspec tests need to be written for solaris_providers protocol_properties
 * 25191982 puppet type 'dns' is not able to set 'options' property in resolv.conf
+* 25192742 puppet svccfg shouldn't try to update properties for a non-existent fmri
 * 25196056 puppet interface and address _properties namevars are problematic
 * 25211935 puppet link_aggregation needs to permanently delete before modifying temporary
 * 25217063 puppet protocol_properties is not idempotent

--- a/lib/puppet/provider/address_object/solaris.rb
+++ b/lib/puppet/provider/address_object/solaris.rb
@@ -144,6 +144,10 @@ Puppet::Type.type(:address_object).provide(:address_object) do
       options << "-a" << "remote=#{remote_address}"
     end
 
+    if @resource[:routername]
+      options << "-n" << resource[:routername]
+    end
+
     if @resource[:down] == :true
       options << "-d"
     end

--- a/lib/puppet/provider/pkg_publisher/solaris.rb
+++ b/lib/puppet/provider/pkg_publisher/solaris.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:pkg_publisher).provide(:pkg_publisher) do
 
       # set the order of the publishers
       if not publisher_order.include?("name")
-        publisher_order << name
+        publisher_order.push name
       end
       # strip off any trailing "/" characters
       if origin.end_with?("/")
@@ -63,7 +63,7 @@ Puppet::Type.type(:pkg_publisher).provide(:pkg_publisher) do
 
         index = publisher_order.index(name)
         if index == 0
-          publishers[name]["searchfirst"] = true
+          publishers[name]["searchfirst"] = :true
           publishers[name]["searchafter"] = nil
         else
           publishers[name]["searchfirst"] = nil

--- a/lib/puppet/type/nsswitch.rb
+++ b/lib/puppet/type/nsswitch.rb
@@ -15,7 +15,7 @@
 #
 
 Puppet::Type.newtype(:nsswitch) do
-  @doc = "Name service switch configuration data"
+  @doc = "Name service switch configuration data. See: nsswitch.conf(5)"
 
   newparam(:name) do
     desc "The symbolic name for the nsswitch settings to use.  This name
@@ -101,5 +101,13 @@ Puppet::Type.newtype(:nsswitch) do
 
   newproperty(:sudoer) do
     desc "The sudoer database lookup override.  Used with sudo only"
+  end
+
+  newproperty(:ipnodes) do
+    desc "The ipnodes database lookup override."
+  end
+
+  newproperty(:protocol) do
+    desc "The protocol database lookup override."
   end
 end

--- a/spec/unit/provider/address_object/address_object_spec.rb
+++ b/spec/unit/provider/address_object/address_object_spec.rb
@@ -34,6 +34,8 @@ describe Puppet::Type.type(:address_object).provider(:address_object) do
     [
       [:temporary,:true,%w(-t)],
       [:address_type,:static,["-T", :static]],
+      [:address_type,:vrrp,["-T", :vrrp]],
+      [:routername,'1.2.3.4',["-n", '1.2.3.4']],
       [:address_type,:dhcp,["-T", :dhcp]],
       [:address,"1.2.3.4",%w(-a local=1.2.3.4)],
       [:remote_address,"1.2.3.4",%w(-a remote=1.2.3.4)],

--- a/spec/unit/provider/pkg/pkg_publisher_spec.rb
+++ b/spec/unit/provider/pkg/pkg_publisher_spec.rb
@@ -45,7 +45,7 @@ describe Puppet::Type.type(:pkg_publisher).provider(:pkg_publisher) do
         :proxy => nil,
         :searchafter => nil,
         :searchbefore => nil,
-        :searchfirst => true,
+        :searchfirst => :true,
         :sslcert => nil,
         :sslkey => nil,
         :sticky => "true"
@@ -73,7 +73,7 @@ describe Puppet::Type.type(:pkg_publisher).provider(:pkg_publisher) do
         :proxy => nil,
         :searchafter => nil,
         :searchbefore => nil,
-        :searchfirst => true,
+        :searchfirst => :true,
         :sslcert => nil,
         :sslkey => nil,
         :sticky => "true"

--- a/spec/unit/provider/svccfg/svccfg_spec.rb
+++ b/spec/unit/provider/svccfg/svccfg_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Type.type(:svccfg).provider(:svccfg) do
 
   let(:params) do
     {
-      :name => "foo", :ensure => :present,
+      :name => "foo",
       :fmri => "svc:/application/puppet:agent",
       :property => "refresh/timeout_seconds",
       :type => "count",

--- a/spec/unit/type/address_object_spec.rb
+++ b/spec/unit/type/address_object_spec.rb
@@ -167,6 +167,10 @@ describe Puppet::Type.type(:address_object) do
           :remote_interface_id => {
             :accepts => [],
             :rejects => [ "::1a:2b:3c:4d" ] },
+          :routername => {
+            :accepts => [],
+            :rejects => [ "1.2.3.256" ],
+          },
         }.each_pair { |target_param,cond|
           context "#{target_param}" do
             context "accepts" do
@@ -189,6 +193,64 @@ describe Puppet::Type.type(:address_object) do
           end
         }
       end # end static
+
+      context "vrrp" do
+        before (:each) { params[:address_type] = :vrrp }
+        {
+          :routername => {
+            :accepts => ["foo.com","2.3.4.5"],
+            :rejects => [ "1.2.3.256" ],
+          },
+          :address => {
+            :accepts => [ "1.2.3.4"],
+            :rejects => [ "1.2.3.256" ],
+          },
+          :remote_address => {
+            :accepts => [],
+            :rejects => [ "1.2.3.4" ],
+          },
+          :down => {
+            :accepts => [],
+            :rejects => [ "true", "false" ],
+          },
+          :seconds => {
+            :accepts => [],
+            :rejects => [5,"10","forever"],
+          },
+          :hostname => {
+            :accepts => [],
+            :rejects => ["foo.com"],
+          },
+          :interface_id => {
+            :accepts => [],
+            :rejects => ["::1a:2b:3c:4d"]
+          },
+          :remote_interface_id => {
+            :accepts => [],
+            :rejects => ["::1a:2b:3c:4d"]
+          },
+        }.each_pair { |target_param,cond|
+          context "#{target_param}" do
+            context "accepts" do
+              cond[:accepts].each do |thing|
+                it thing.inspect do
+                  params[target_param] = thing
+                  expect { resource }.not_to raise_error
+                end
+              end
+            end # Accepts
+            context "rejects" do
+              cond[:rejects].each do |thing|
+                it thing.inspect do
+                  error_pattern = %r(is invalid|cannot specify)
+                  params[target_param] = thing
+                  expect { resource }.to raise_error(Puppet::Error, error_pattern)
+                end
+              end
+            end # Rejects
+          end
+        }
+      end # End vrrp
 
       context "dhcp" do
         before (:each) { params[:address_type] = :dhcp }
@@ -220,6 +282,10 @@ describe Puppet::Type.type(:address_object) do
           :remote_interface_id => {
             :accepts => [],
             :rejects => ["::1a:2b:3c:4d"]
+          },
+          :routername => {
+            :accepts => [],
+            :rejects => [ "1.2.3.256" ],
           },
         }.each_pair { |target_param,cond|
           context "#{target_param}" do
@@ -274,6 +340,10 @@ describe Puppet::Type.type(:address_object) do
             :accepts => ["::1a:2b:3c:4d"],
             :rejects => [],
           },
+          :routername => {
+            :accepts => [],
+            :rejects => [ "1.2.3.256" ],
+          },
         }.each_pair { |target_param,cond|
           context "#{target_param}" do
             context "accepts" do
@@ -327,6 +397,10 @@ describe Puppet::Type.type(:address_object) do
             :remote_interface_id => {
               :accepts => [],
               :rejects => ["::1a:2b:3c:4d"],
+            },
+            :routername => {
+              :accepts => [],
+              :rejects => [ "1.2.3.256" ],
             },
           }.each_pair { |target_param,cond|
             context "#{target_param}" do


### PR DESCRIPTION
19429313 address_object type should support vrrp addresses
19888183 publisher provider is applied on each puppet run
22072780 pkg_publisher provider applies 'searchfirst' every time
22125767 nsswitch provider missing ipnodes, protocols
