### PR TITLE
26452898 beadm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 2.1.0
+## New Features
+* boot_environment
+  * Now shows the created timestamp of the BE
+* pkg_publisher
+  * supports unique proxies, ssl certs, and ssl keys per origin
+
+## Impacting Changes
+* boot_environemnt
+  * Providing a value which does not match the running state to 'running' is now
+    an error instead of a warning. The running value should not be provided
+    except as a mechanism to detect a change in the running BE.
+
+## Bugs Fixes and Enhancements
+* 26137448 puppet pkg_publisher does not work for slightly complex configurations
+* 26137407 puppet pkg_publisher provider is not idempotent with ssl certs and keys
+* 26452898 puppet boot_environment should show created timestamp
+
 # 2.0.2
 ## Impacting Changes
 * svccfg

--- a/lib/puppet/type/boot_environment.rb
+++ b/lib/puppet/type/boot_environment.rb
@@ -69,8 +69,12 @@ Puppet::Type.newtype(:boot_environment) do
   end
 
   newproperty(:running) do
-    desc "An existing BE may be Active and/or Running. This parameter has no
-          effect on behavior and exists only for display purposes."
+    desc "An existing BE may be Active and/or Running. Display only.
+          Providing a non-matching value will result in an Error during
+          catalog application.
+
+          This value may be used to detect unexpected changes in the running BE.
+          "
     newvalues(:true,:false)
   end
 
@@ -78,6 +82,14 @@ Puppet::Type.newtype(:boot_environment) do
     desc "Activate the specified BE. Only one BE may be active at a time.
     Activating an instance does not reboot the system to change the running BE."
     newvalues(:true, :false)
+  end
+
+  newproperty(:created) do
+    desc "Creation timestamp. Display only"
+
+    def insync?(is)
+      true
+    end
   end
 
   validate do

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "oracle-solaris_providers",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "author": "Oracle",
   "summary": "Oracle Solaris Providers",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
         {
             "operatingsystem": "Solaris",
             "operatingsystemrelease": [
-                "11",
+                "11.4",
                 "12"
             ]
         }
@@ -32,6 +32,10 @@
     "facet",
     "mediator",
     "publisher",
-    "variant"
+    "variant",
+    "boot_environment",
+    "zfs",
+    "elastic_virtual_switch",
+    "ipmp"
   ]
 }

--- a/spec/unit/provider/boot_environment/boot_environment_spec.rb
+++ b/spec/unit/provider/boot_environment/boot_environment_spec.rb
@@ -42,7 +42,7 @@ describe Puppet::Type.type(:boot_environment).provider(:boot_environment) do
                                   my_fixture('beadm_list_H.txt'))
     instances = described_class.instances.map { |p|
       hsh={}
-      [:name, :activate, :ensure, :running].each { |fld|
+      [:name, :activate, :ensure, :running, :created].each { |fld|
         hsh[fld] = p.get(fld)
       }
       hsh
@@ -57,10 +57,16 @@ describe Puppet::Type.type(:boot_environment).provider(:boot_environment) do
     it "first instance is running" do
       expect(instances[0][:running]).to eq(:true)
     end
+    it "first instance has expected created" do
+      # Don't use stringified time for comparison
+      expect(instances[0][:created]).to eq(Time.at(1481572424))
+    end
     it "last instance is s12b113-backup-1" do
       expect(instances[-1]).to eq(
                                  {:name=>"s12b113-backup-1", :activate=>:false,
-                                  :ensure=>:present, :running => :false}
+                                  :ensure=>:present, :running => :false,
+                                  :created => Time.at(1482172700)
+                                }
                                )
     end
   end

--- a/spec/unit/type/boot_environment_spec.rb
+++ b/spec/unit/type/boot_environment_spec.rb
@@ -26,7 +26,7 @@ describe Puppet::Type.type(:boot_environment) do
   end
 
   describe "has property" do
-    [ :activate, ].each { |prop|
+    [ :activate, :running, :created ].each { |prop|
       it prop do
         expect(described_class.attrtype(prop)).to be == :property
       end


### PR DESCRIPTION
Bump version to 2.1.0
Change required Solaris version to 11.4
26452898 puppet boot_environment should show created timestamp
