### PR TITLE
fix `post_resource_eval` errror

### DIFF
--- a/lib/puppet/provider/pkg_facet/solaris.rb
+++ b/lib/puppet/provider/pkg_facet/solaris.rb
@@ -62,14 +62,14 @@ Puppet::Type.type(:pkg_facet).provide(:solaris) do
 
   def defer(arg)
     Puppet.debug "Defering facet: #{arg}"
-    cv = Puppet::Type::Pkg_facet::ProviderPkg_facet.send(:class_variable_get, :@@classvars)
+    cv = Puppet::Type::Pkg_facet::ProviderSolaris.send(:class_variable_get, :@@classvars)
     cv[:changes].push arg
-    Puppet::Type::Pkg_facet::ProviderPkg_facet.send(:class_variable_set, :@@classvars, cv)
+    Puppet::Type::Pkg_facet::ProviderSolaris.send(:class_variable_set, :@@classvars, cv)
   end
 
   def self.post_resource_eval
     # Apply any stashed changes and remove the class variable
-    cv = Puppet::Type::Pkg_facet::ProviderPkg_facet.send(:class_variable_get, :@@classvars)
+    cv = Puppet::Type::Pkg_facet::ProviderSolaris.send(:class_variable_get, :@@classvars)
     # If changes have been stashed apply them
     unless cv[:changes].empty?
       Puppet.debug("Applying %s defered facet changes" % cv[:changes].length)
@@ -77,7 +77,7 @@ Puppet::Type.type(:pkg_facet).provide(:solaris) do
     end
 
     # Cleanup our tracking class variable
-    Puppet::Type::Pkg_facet::ProviderPkg_facet.send(:remove_class_variable, :@@classvars)
+    Puppet::Type::Pkg_facet::ProviderSolaris.send(:remove_class_variable, :@@classvars)
   end
 
   # required puppet functions


### PR DESCRIPTION
Fixes this error on Solaris 11.4

`Error: post_resource_eval failed for provider Puppet::Type::Pkg_facet::ProviderSolaris`