### PR TITLE
28967679 puppet module missing cluster keyword

### DIFF
--- a/lib/puppet/type/nsswitch.rb
+++ b/lib/puppet/type/nsswitch.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,8 +45,8 @@ The following database limitations are also applicable:
       # Mostly validate options ignoring any additional criteria
       validate do |value|
         unless prop == :printer
-          expr=%r(\b(files|ldap|dns)\b|:\[.*\]|\s)
-          expr_spc=%r(\b(files|ldap|dns)\b|:\[.*\])
+          expr=%r(\b(files|ldap|dns|cluster)\b|:\[.*\]|\s)
+          expr_spc=%r(\b(files|ldap|dns|cluster)\b|:\[.*\])
         else
           expr=%r(\b(files|ldap|dns|user)\b|:\[.*\]|\s)
           expr_spc=%r(\b(files|ldap|dns|user)\b|:\[.*\])


### PR DESCRIPTION
The Solaris Cluster uses 'cluster' as DB for hosts/ipnodes/netmasks,
nsswitch module does not allow it.
The fix ensures that "cluster" is part of the allowed database names.  
Tests:
Manifest file on puppet master
```
$ cat /etc/puppetlabs/code/environments/production/manifests/site.pp
nsswitch { "current":
  ensure => "present",
  alias  => "files ldap",
  netmask  => "files cluster",
  host  => "files ldap cluster",
}
$ puppet agent -t
$ cat /etc/nsswitch.conf

//#
//# _AUTOGENERATED_FROM_SMF_V1_
//#
//# WARNING: THIS FILE GENERATED FROM SMF DATA.
//#   DO NOT EDIT THIS FILE.  EDITS WILL BE LOST.
//# See nsswitch.conf(5) for details.

passwd: files ldap
group:  files ldap
hosts:  files ldap cluster
ipnodes:        files ldap cluster
....
....
....
netmasks:       files cluster

--- /var/puppetlabs/puppet/cache/lib/puppet/type/nsswitch.rb    2020-12-02 17:42:51.061706135 +0000
+++ /tmp/puppet-file20210216-1600-cep74j        2021-02-16 11:10:18.716687945 +0000
@@ -45,8 +45,8 @@
     # Mostly validate options ignoring any additional criteria
     validate do |value|
       unless prop == :printer
-        expr=%r(\b(files|ldap|dns)\b|:\[.*\]|\s)
-        expr_spc=%r(\b(files|ldap|dns)\b|:\[.*\])
+        expr=%r(\b(files|ldap|dns|cluster)\b|:\[.*\]|\s)
+        expr_spc=%r(\b(files|ldap|dns|cluster)\b|:\[.*\])
       else
         expr=%r(\b(files|ldap|dns|user)\b|:\[.*\]|\s)
         expr_spc=%r(\b(files|ldap|dns|user)\b|:\[.*\])
$ cat /var/log/puppetlabs/puppet/puppet-agent.log
2021-02-16 11:10:18 +0000 /File[/var/puppetlabs/puppet/cache/lib/puppet/type/nsswitch.rb]/content (notice): content changed '{md5}fcef4e503728d873d594eb817bda0f60' to '{md5}8ff16fa93cd968de5ad9ff6a160871a0'
2021-02-16 11:10:18 +0000 Puppet (info): Retrieving locales
2021-02-16 11:10:19 +0000 Puppet (info): Loading facts
2021-02-16 11:10:54 +0000 Puppet (info): Caching catalog for XXXXXXX
2021-02-16 11:10:54 +0000 Puppet (info): Applying configuration version '1613473853'
2021-02-16 11:10:55 +0000 /Stage[main]/Main/Nsswitch[current]/host (notice): host changed 'files dns' to 'files ldap cluster'

```