### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group(:development, :test) do
   gem 'puppetlabs_spec_helper', :require => true
   gem 'rspec-puppet', :require => true
   gem 'rspec', :require => false
-  gem 'rake', '< 11.0', :require => false
+  gem 'rake', '>= 12.3.3', :require => false
   gem 'pry', :require => false
   gem 'pry-rescue', :require => false
   gem 'pry-stack_explorer', :require => false
@@ -19,6 +19,6 @@ group(:development, :test) do
   gem 'redcarpet'
 end
 
-gem "rubocop", "~> 0.26.1", :platforms => [:ruby]
+gem "rubocop", ">= 0.49.0", :platforms => [:ruby]
 gem 'beaker', '~> 2.0', :require => false, :group => :acceptance
 gem 'beaker-rspec', '5.6.0', :require => false, :group => :acceptance


### PR DESCRIPTION
Update dependencies in Gemfile

Test suite executed:
 $git branch
* fix/oracle/Gemfile
  master

```
 $ bundle exec rake spec
I, [2021-04-22T18:02:49.312726 #6699]  INFO -- : Creating symlink from spec/fixtures/modules/solaris_providers to /scratch/swdevula/puppet-cve/oracle/puppet-solaris_providers
Cloning into 'spec/fixtures/modules/stdlib'...
remote: Enumerating objects: 565, done.
remote: Counting objects: 100% (565/565), done.
remote: Compressing objects: 100% (529/529), done.
Receiving objects:  78% (441remote: Total 565 (delta 147), reused 113 (delta 11), pack-reused 0
Receiving objects: 100% (565/565), 351.28 KiB | 10.33 MiB/s, done.
Resolving deltas: 100% (147/147), done.
/usr/ruby/2.6/bin/ruby -I/scratch/swdevula/puppet-cve/oracle/puppet-solaris_providers/vendor/cache/ruby/2.6.0/gems/rspec-core-3.10.1/lib:/scratch/swdevula/puppet-cve/oracle/puppet-solaris_providers/vendor/cache/ruby/2.6.0/gems/rspec-support-3.10.2/lib /scratch/swdevula/puppet-cve/oracle/puppet-solaris_providers/vendor/cache/ruby/2.6.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit\}/\*\*/\*_spec.rb
.........................................................................................................................................................................................................................................................................................................................................................................*.......................................................................................................................................................................................................................................................................................................**.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Puppet::Type::Nsswitch::ProviderSolaris verify alias processing it fails in puppet 3.6.2 spec tests
     # Temporarily skipped with xit
     # ./spec/unit/puppet/provider/nsswitch/solaris_spec.rb:97

  2) Puppet::Type::Svccfg::ProviderSolaris#delcust should delcust
     # Not yet implemented
     # ./spec/unit/puppet/provider/svccfg/solaris_spec.rb:430

  3) Puppet::Type::Svccfg::ProviderSolaris#delcust should delcust property
     # Not yet implemented
     # ./spec/unit/puppet/provider/svccfg/solaris_spec.rb:431


Deprecation Warnings:

puppetlabs_spec_helper: defaults `mock_with` to `:mocha`. See https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with to choose a sensible value for you


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 1 minute 9.79 seconds (files took 8.32 seconds to load)
2192 examples, 0 failures, 3 pending


```

