### PR TITLE
Update Puppet version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group(:development, :test) do
   gem 'pry-rescue', :require => false
   gem 'pry-stack_explorer', :require => false
   gem 'psych', :require => false
-  gem 'puppet', '4.7.0', :require => true
+  gem 'puppet', '5.5.21', :require => true
   gem 'pkg-config', :require => false
   gem 'semantic_puppet'
   # Docs


### PR DESCRIPTION
Updated Puppet version in Gemfile. Puppet 5.5.21 is currently supported version on Solaris

Test suite executed:

```
$  bundle exec rake spec
I, [2021-05-10T09:46:30.350341 #11509]  INFO -- : Creating symlink from spec/fixtures/modules/solaris_providers to /scratch/swdevula/puppet-cve/oracle/puppet-solaris_providers
Cloning into 'spec/fixtures/modules/stdlib'...
remote: Enumerating objects: 565, done.
remote: Counting objects: 100% (565/565), done.
remote: Compressing objects: 100% (529/529), done.
remote: Total 565 (delta 147), reused 111 (delta 11), pack-reused 0
Receiving objects: 100% (565/565), 358.65 KiB | 10.25 MiB/s, done.
Resolving deltas: 100% (147/147), done.
/usr/ruby/2.6/bin/ruby -I/scratch/swdevula/puppet-cve/oracle/puppet-solaris_providers/vendor/cache/ruby/2.6.0/gems/rspec-core-3.10.1/lib:/scratch/swdevula/puppet-cve/oracle/puppet-solaris_providers/vendor/cache/ruby/2.6.0/gems/rspec-support-3.10.2/lib /scratch/swdevula/puppet-cve/oracle/puppet-solaris_providers/vendor/cache/ruby/2.6.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit\}/\*\*/\*_spec.rb
.........................................................................................................................................................................................................................................................................................................................................................................*.......................................................................................................................................................................................................................................................................................................**.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Puppet::Type::Nsswitch::ProviderSolaris verify alias processing it fails in puppet 3.6.2 spec tests
     # Temporarily skipped with xit
     # ./spec/unit/puppet/provider/nsswitch/solaris_spec.rb:97

  2) Puppet::Type::Svccfg::ProviderSolaris#delcust should delcust
     # Not yet implemented
     # ./spec/unit/puppet/provider/svccfg/solaris_spec.rb:430

  3) Puppet::Type::Svccfg::ProviderSolaris#delcust should delcust property
     # Not yet implemented
     # ./spec/unit/puppet/provider/svccfg/solaris_spec.rb:431


Deprecation Warnings:

puppetlabs_spec_helper: defaults `mock_with` to `:mocha`. See https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with to choose a sensible value for you


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 1 minute 10.96 seconds (files took 6.38 seconds to load)
2192 examples, 0 failures, 3 pending
```

