### PR TITLE
Update Ruby and Puppet versions in travis test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,20 @@ language: ruby
 sudo: false
 before_install:
   - gem install bundler -v 1.10
-  - echo "gem 'rake', '< 11.0'" >> Gemfile
+  - echo "gem 'rake', '>= 12.3.3'" >> Gemfile
 bundler_args: --without acceptance
 script:
   - "bundle exec rake $CHECK"
 notifications:
   email: false
 rvm:
-  - 2.3.0-dev
-  - 2.2.4
-  # Current in Solaris 12
-  - 2.1.6
+  # Current in Solaris 11
+  - 2.6.6
 
 gemfile: 
-    # Solaris 12 Version of Puppet is 3.8.6
+    # Solaris 11 Version of Puppet is 5.x
   - Gemfile
-  - Gemfiles/puppet-4.x
+  - Gemfiles/puppet-5.x
 
 env:
   - "CHECK=spec"
@@ -25,7 +23,7 @@ env:
 matrix:
   allow_failures:
     - env: "CHECK=rubocop"
-    - rvm: 2.3.0-dev
+    - rvm: 2.6.6
   exclude:
     # Can't run Puppet < 4.x with Ruby >= 2.2
     - rvm: 2.2.4 
@@ -34,10 +32,6 @@ matrix:
       gemfile: Gemfile
   include:
     # Add one run for older Solaris 11 Ruby and Puppet
-    - rvm: 1.9.3
-      gemfile: Gemfiles/puppet-3.6.2
+    - rvm: 2.6.6
+      gemfile: Gemfiles/puppet-5.x
       env: CHECK=spec
-    # Add one run of rubocop for Current Solaris 12 Ruby and Puppet
-    - rvm: 2.1.6
-      gemfile: Gemfile
-      env: CHECK=rubocop

--- a/Gemfiles/puppet-5.x
+++ b/Gemfiles/puppet-5.x
@@ -1,0 +1,15 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+group(:development, :test) do
+  gem 'puppetlabs_spec_helper', :require => true
+  gem 'rspec-puppet', :require => true
+  gem 'rspec', :require => false
+  gem 'rake', '>= 12.3.3', :require => false
+  gem 'psych', :require => false
+  gem 'puppet', '5.5.21', :require => true
+  gem 'pkg-config', :require => false
+end
+
+gem "rubocop", ">= 0.49.0", :platforms => [:ruby]
+
+gem 'beaker-rspec', :require => false, :group => :acceptance


### PR DESCRIPTION
The changes to .travis.yml file that supports the latest versions of Ruby and Puppet, allows Travis CI tests to pass.