### PR TITLE
Merging code from Solaris IPS package to upstream code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Oracle Solaris Providers override the core Puppet providers for:
 
 ## Setup
 
-For Solaris 11.x pkg install puppet
+For Solaris 11.4 (onwards) pkg install puppet
 
 No additional setup or configuration is required.
 

--- a/docs/puppet_providers_address_object/address_object.html
+++ b/docs/puppet_providers_address_object/address_object.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_address_properties/address_properties.html
+++ b/docs/puppet_providers_address_properties/address_properties.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_boot_environment/boot_environment.html
+++ b/docs/puppet_providers_boot_environment/boot_environment.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_dns/dns.html
+++ b/docs/puppet_providers_dns/dns.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_etherstub/etherstub.html
+++ b/docs/puppet_providers_etherstub/etherstub.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_evs/evs.html
+++ b/docs/puppet_providers_evs/evs.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ["5.11", "5.12"]</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ["5.11"]</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_evs_ipnet/evs_ipnet.html
+++ b/docs/puppet_providers_evs_ipnet/evs_ipnet.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ["5.11", "5.12"]</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ["5.11"]</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_evs_properties/evs_properties.html
+++ b/docs/puppet_providers_evs_properties/evs_properties.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ["5.11", "5.12"]</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ["5.11"]</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_evs_vport/evs_vport.html
+++ b/docs/puppet_providers_evs_vport/evs_vport.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ["5.11", "5.12"]</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ["5.11"]</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_ilb_healthcheck/ilb_healthcheck.html
+++ b/docs/puppet_providers_ilb_healthcheck/ilb_healthcheck.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_ilb_rule/ilb_rule.html
+++ b/docs/puppet_providers_ilb_rule/ilb_rule.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_ilb_server/ilb_server.html
+++ b/docs/puppet_providers_ilb_server/ilb_server.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_ilb_servergroup/ilb_servergroup.html
+++ b/docs/puppet_providers_ilb_servergroup/ilb_servergroup.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_interface_properties/interface_properties.html
+++ b/docs/puppet_providers_interface_properties/interface_properties.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_ip_interface/ip_interface.html
+++ b/docs/puppet_providers_ip_interface/ip_interface.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_ip_tunnel/ip_tunnel.html
+++ b/docs/puppet_providers_ip_tunnel/ip_tunnel.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_ipmp_interface/ipmp_interface.html
+++ b/docs/puppet_providers_ipmp_interface/ipmp_interface.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_ldap/ldap.html
+++ b/docs/puppet_providers_ldap/ldap.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_link_aggregation/link_aggregation.html
+++ b/docs/puppet_providers_link_aggregation/link_aggregation.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_link_properties/link_properties.html
+++ b/docs/puppet_providers_link_properties/link_properties.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_nis/nis.html
+++ b/docs/puppet_providers_nis/nis.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_nsswitch/nsswitch.html
+++ b/docs/puppet_providers_nsswitch/nsswitch.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_pkg_facet/pkg_facet.html
+++ b/docs/puppet_providers_pkg_facet/pkg_facet.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_pkg_mediator/pkg_mediator.html
+++ b/docs/puppet_providers_pkg_mediator/pkg_mediator.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_pkg_publisher/pkg_publisher.html
+++ b/docs/puppet_providers_pkg_publisher/pkg_publisher.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_pkg_variant/pkg_variant.html
+++ b/docs/puppet_providers_pkg_variant/pkg_variant.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_process_scheduler/process_scheduler.html
+++ b/docs/puppet_providers_process_scheduler/process_scheduler.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_protocol_properties/protocol_properties.html
+++ b/docs/puppet_providers_protocol_properties/protocol_properties.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_solaris_vlan/solaris_vlan.html
+++ b/docs/puppet_providers_solaris_vlan/solaris_vlan.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_system_attributes/system_attributes.html
+++ b/docs/puppet_providers_system_attributes/system_attributes.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_vni_interface/vni_interface.html
+++ b/docs/puppet_providers_vni_interface/vni_interface.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_vnic/vnic.html
+++ b/docs/puppet_providers_vnic/vnic.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/docs/puppet_providers_zfs_acl/zfs_acl.html
+++ b/docs/puppet_providers_zfs_acl/zfs_acl.html
@@ -105,7 +105,7 @@
 
   
     
-      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11', '5.12']</tt></li>
+      <li><tt>osfamily &mdash; solaris, kernelrelease &mdash; ['5.11']</tt></li>
     
   
   </ul>

--- a/lib/puppet/provider/address_object/solaris.rb
+++ b/lib/puppet/provider/address_object/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:address_object).provide(:solaris) do
   desc "Provider for creating Oracle Solaris address objects"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ipadm => '/usr/sbin/ipadm'
 
   mk_resource_methods

--- a/lib/puppet/provider/address_object/solaris.rb
+++ b/lib/puppet/provider/address_object/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/address_properties/solaris.rb
+++ b/lib/puppet/provider/address_properties/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:address_properties).provide(:solaris) do
   desc "Provider for managing Oracle Solaris address object properties"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ipadm => '/usr/sbin/ipadm'
 
   mk_resource_methods

--- a/lib/puppet/provider/address_properties/solaris.rb
+++ b/lib/puppet/provider/address_properties/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/boot_environment/solaris.rb
+++ b/lib/puppet/provider/boot_environment/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:boot_environment).provide(:solaris) do
   desc "Provider for Oracle Solaris Boot Environments (BEs)"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   # We have a parameter zpool which masks this definition
   commands :beadm => '/usr/sbin/beadm', :zpool_cmd => '/usr/sbin/zpool'
 

--- a/lib/puppet/provider/boot_environment/solaris.rb
+++ b/lib/puppet/provider/boot_environment/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/dns/solaris.rb
+++ b/lib/puppet/provider/dns/solaris.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:dns).provide(:solaris,
 
   desc "Provider for management of DNS for Oracle Solaris"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :svccfg => '/usr/sbin/svccfg', :svcprop => '/usr/bin/svcprop'
 
 

--- a/lib/puppet/provider/dns/solaris.rb
+++ b/lib/puppet/provider/dns/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/etherstub/solaris.rb
+++ b/lib/puppet/provider/etherstub/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:etherstub).provide(:solaris) do
   desc "Provider for creating Solaris etherstubs"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :dladm => '/usr/sbin/dladm'
 
   def self.instances

--- a/lib/puppet/provider/etherstub/solaris.rb
+++ b/lib/puppet/provider/etherstub/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/evs/solaris.rb
+++ b/lib/puppet/provider/evs/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/evs/solaris.rb
+++ b/lib/puppet/provider/evs/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:evs).provide(:solaris) do
   desc "Provider for managing EVS setup in the Solaris OS"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ["5.11", "5.12"]
+  defaultfor :osfamily => :solaris, :kernelrelease => ["5.11"]
   commands :evsadm => "/usr/sbin/evsadm"
 
   mk_resource_methods

--- a/lib/puppet/provider/evs_ipnet/solaris.rb
+++ b/lib/puppet/provider/evs_ipnet/solaris.rb
@@ -18,7 +18,7 @@
 Puppet::Type.type(:evs_ipnet).provide(:solaris) do
   desc "Provider for managing EVS IPnet setup in the Solaris OS"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ["5.11", "5.12"]
+  defaultfor :osfamily => :solaris, :kernelrelease => ["5.11"]
   commands :evsadm => "/usr/sbin/evsadm"
 
   mk_resource_methods

--- a/lib/puppet/provider/evs_ipnet/solaris.rb
+++ b/lib/puppet/provider/evs_ipnet/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/evs_properties/solaris.rb
+++ b/lib/puppet/provider/evs_properties/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:evs_properties).provide(:solaris) do
   desc "Provider for managing Oracle Solaris EVS properties"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ["5.11", "5.12"]
+  defaultfor :osfamily => :solaris, :kernelrelease => ["5.11"]
   commands :evsadm => "/usr/sbin/evsadm"
 
   mk_resource_methods

--- a/lib/puppet/provider/evs_properties/solaris.rb
+++ b/lib/puppet/provider/evs_properties/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/evs_vport/solaris.rb
+++ b/lib/puppet/provider/evs_vport/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/evs_vport/solaris.rb
+++ b/lib/puppet/provider/evs_vport/solaris.rb
@@ -18,7 +18,7 @@
 Puppet::Type.type(:evs_vport).provide(:solaris) do
   desc "Provider for managing EVS VPort setup in the Solaris OS"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ["5.11", "5.12"]
+  defaultfor :osfamily => :solaris, :kernelrelease => ["5.11"]
   commands :evsadm => "/usr/sbin/evsadm"
 
   mk_resource_methods

--- a/lib/puppet/provider/ilb_healthcheck/solaris.rb
+++ b/lib/puppet/provider/ilb_healthcheck/solaris.rb
@@ -18,7 +18,7 @@
 Puppet::Type.type(:ilb_healthcheck).provide(:solaris) do
   @doc = "Provider to manage Solaris Integrated Load Balancer (ILB) health checks."
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ilbadm => '/usr/sbin/ilbadm'
 
   mk_resource_methods

--- a/lib/puppet/provider/ilb_healthcheck/solaris.rb
+++ b/lib/puppet/provider/ilb_healthcheck/solaris.rb
@@ -1,6 +1,6 @@
 
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/ilb_rule/solaris.rb
+++ b/lib/puppet/provider/ilb_rule/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/ilb_rule/solaris.rb
+++ b/lib/puppet/provider/ilb_rule/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:ilb_rule).provide(:solaris) do
   @doc = "Provider to manage Solaris Integrated Load Balancer (ILB) rule configuration."
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ilbadm => '/usr/sbin/ilbadm'
 
   mk_resource_methods

--- a/lib/puppet/provider/ilb_server/solaris.rb
+++ b/lib/puppet/provider/ilb_server/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/ilb_server/solaris.rb
+++ b/lib/puppet/provider/ilb_server/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:ilb_server).provide(:solaris) do
   @doc = "Provider to manage Solaris Integrated Load Balancer (ILB) server configuration."
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ilbadm => '/usr/sbin/ilbadm'
 
   mk_resource_methods

--- a/lib/puppet/provider/ilb_servergroup/solaris.rb
+++ b/lib/puppet/provider/ilb_servergroup/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/ilb_servergroup/solaris.rb
+++ b/lib/puppet/provider/ilb_servergroup/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:ilb_servergroup).provide(:solaris) do
   @doc = "Provider to manage Solaris Integrated Load Balancer (ILB) server group configuration."
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ilbadm => '/usr/sbin/ilbadm'
 
   mk_resource_methods

--- a/lib/puppet/provider/interface_properties/solaris.rb
+++ b/lib/puppet/provider/interface_properties/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/interface_properties/solaris.rb
+++ b/lib/puppet/provider/interface_properties/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:interface_properties).provide(:solaris) do
   desc "Provider for managing Oracle Solaris interface properties"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ipadm => '/usr/sbin/ipadm'
 
   mk_resource_methods

--- a/lib/puppet/provider/ip_interface/solaris.rb
+++ b/lib/puppet/provider/ip_interface/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:ip_interface).provide(:solaris) do
   desc "Provider for management of IP interfaces for Oracle Solaris"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ipadm => '/usr/sbin/ipadm', :dladm => '/usr/sbin/dladm'
 
   def self.instances

--- a/lib/puppet/provider/ip_interface/solaris.rb
+++ b/lib/puppet/provider/ip_interface/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/ip_tunnel/solaris.rb
+++ b/lib/puppet/provider/ip_tunnel/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/ip_tunnel/solaris.rb
+++ b/lib/puppet/provider/ip_tunnel/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:ip_tunnel).provide(:solaris) do
   desc "Provider for managing Oracle Solaris IP Tunnel links"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :dladm => '/usr/sbin/dladm'
 
   def self.instances

--- a/lib/puppet/provider/ipmp_interface/solaris.rb
+++ b/lib/puppet/provider/ipmp_interface/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/ipmp_interface/solaris.rb
+++ b/lib/puppet/provider/ipmp_interface/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:ipmp_interface).provide(:solaris) do
   desc "Provider for management of IPMP interfaces for Oracle Solaris"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ipadm => '/usr/sbin/ipadm'
 
   mk_resource_methods

--- a/lib/puppet/provider/ldap/solaris.rb
+++ b/lib/puppet/provider/ldap/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/ldap/solaris.rb
+++ b/lib/puppet/provider/ldap/solaris.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:ldap).provide(:solaris,
 
   desc "Provider for management of the LDAP client for Oracle Solaris"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :svccfg => '/usr/sbin/svccfg', :svcprop => '/usr/bin/svcprop'
 
   Ldap_fmri = "svc:/network/ldap/client".freeze

--- a/lib/puppet/provider/link_aggregation/solaris.rb
+++ b/lib/puppet/provider/link_aggregation/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:link_aggregation).provide(:solaris) do
   desc "Provider for creating Oracle Solaris link aggregations"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :dladm => '/usr/sbin/dladm'
 
   mk_resource_methods

--- a/lib/puppet/provider/link_aggregation/solaris.rb
+++ b/lib/puppet/provider/link_aggregation/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/link_properties/solaris.rb
+++ b/lib/puppet/provider/link_properties/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:link_properties).provide(:solaris) do
   desc "Provider for managing Oracle Solaris link properties"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :dladm => '/usr/sbin/dladm'
 
   mk_resource_methods

--- a/lib/puppet/provider/link_properties/solaris.rb
+++ b/lib/puppet/provider/link_properties/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/nis/solaris.rb
+++ b/lib/puppet/provider/nis/solaris.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:nis).provide(:solaris,
 
   desc "Provider for management of NIS client for Oracle Solaris"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :svccfg => '/usr/sbin/svccfg', :svcprop => '/usr/bin/svcprop'
 
   class << self; attr_accessor :client_fmri, :domain_fmri end

--- a/lib/puppet/provider/nis/solaris.rb
+++ b/lib/puppet/provider/nis/solaris.rb
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+#   Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/nsswitch/solaris.rb
+++ b/lib/puppet/provider/nsswitch/solaris.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:nsswitch).provide(:solaris,
                              Puppet::Type.type(:svccfg).provider(:solaris)) do
   desc "Provider for name service switch configuration data"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :svccfg => '/usr/sbin/svccfg', :svcprop => '/usr/bin/svcprop'
 
   class << self; attr_accessor :nsswitch_fmri end

--- a/lib/puppet/provider/nsswitch/solaris.rb
+++ b/lib/puppet/provider/nsswitch/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/pkg_facet/solaris.rb
+++ b/lib/puppet/provider/pkg_facet/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:pkg_facet).provide(:solaris) do
   desc "Provider for Oracle Solaris facets"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :pkg => '/usr/bin/pkg'
 
   # Defined classvar once. Access must be via Klass.send to prevent

--- a/lib/puppet/provider/pkg_facet/solaris.rb
+++ b/lib/puppet/provider/pkg_facet/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/pkg_mediator/solaris.rb
+++ b/lib/puppet/provider/pkg_mediator/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:pkg_mediator).provide(:solaris) do
   desc "Provider for Oracle Solaris mediators"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :pkg => '/usr/bin/pkg'
   mk_resource_methods
 

--- a/lib/puppet/provider/pkg_mediator/solaris.rb
+++ b/lib/puppet/provider/pkg_mediator/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/pkg_publisher/solaris.rb
+++ b/lib/puppet/provider/pkg_publisher/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/pkg_publisher/solaris.rb
+++ b/lib/puppet/provider/pkg_publisher/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:pkg_publisher).provide(:solaris) do
   desc "Provider for Solaris publishers"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :pkg => '/usr/bin/pkg'
 
   mk_resource_methods
@@ -29,8 +29,10 @@ Puppet::Type.type(:pkg_publisher).provide(:solaris) do
       name, sticky, _syspub, enabled, type, _status, origin, proxy = line.split
 
       # strip off any trailing "/" characters
-      if origin && origin.end_with?("/")
-        origin = origin[0..-2]
+      unless origin.to_s.strip.empty?
+        if origin.end_with?("/")
+          origin = origin[0..-2]
+        end
       end
 
       unless publishers.key?(name)

--- a/lib/puppet/provider/pkg_variant/solaris.rb
+++ b/lib/puppet/provider/pkg_variant/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/pkg_variant/solaris.rb
+++ b/lib/puppet/provider/pkg_variant/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:pkg_variant).provide(:solaris) do
   desc "Provider for Oracle Solaris variants"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :pkg => '/usr/bin/pkg'
 
   def self.instances

--- a/lib/puppet/provider/process_scheduler/solaris.rb
+++ b/lib/puppet/provider/process_scheduler/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:process_scheduler).provide(:solaris) do
   @doc = "Provider to manage Solaris process scheduler"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :dispadmin => '/usr/sbin/dispadmin'
 
   mk_resource_methods

--- a/lib/puppet/provider/process_scheduler/solaris.rb
+++ b/lib/puppet/provider/process_scheduler/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/protocol_properties/solaris.rb
+++ b/lib/puppet/provider/protocol_properties/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/protocol_properties/solaris.rb
+++ b/lib/puppet/provider/protocol_properties/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:protocol_properties).provide(:solaris) do
   desc "Provider for managing Oracle Solaris protocol object properties"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ipadm => '/usr/sbin/ipadm'
 
   mk_resource_methods

--- a/lib/puppet/provider/solaris_vlan/solaris.rb
+++ b/lib/puppet/provider/solaris_vlan/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/solaris_vlan/solaris.rb
+++ b/lib/puppet/provider/solaris_vlan/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:solaris_vlan).provide(:solaris) do
   desc "Provider for creating Solaris VLANs"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :dladm => '/usr/sbin/dladm'
 
   def self.instances

--- a/lib/puppet/provider/system_attributes/solaris.rb
+++ b/lib/puppet/provider/system_attributes/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/system_attributes/solaris.rb
+++ b/lib/puppet/provider/system_attributes/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:system_attributes).provide(:solaris) do
   desc "Provider for management of file system attributes for Oracle Solaris"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :chmod => '/usr/bin/chmod', :ls => '/usr/bin/ls'
 
   mk_resource_methods

--- a/lib/puppet/provider/vni_interface/solaris.rb
+++ b/lib/puppet/provider/vni_interface/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:vni_interface).provide(:solaris) do
   desc "Provider for management of VNI interfaces for Oracle Solaris"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :ipadm => '/usr/sbin/ipadm'
 
   def self.instances

--- a/lib/puppet/provider/vni_interface/solaris.rb
+++ b/lib/puppet/provider/vni_interface/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/vnic/solaris.rb
+++ b/lib/puppet/provider/vnic/solaris.rb
@@ -17,7 +17,7 @@
 Puppet::Type.type(:vnic).provide(:solaris) do
   desc "Provider for creating VNICs in the Solaris OS"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :dladm => '/usr/sbin/dladm'
 
   mk_resource_methods

--- a/lib/puppet/provider/vnic/solaris.rb
+++ b/lib/puppet/provider/vnic/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/zfs_acl/solaris.rb
+++ b/lib/puppet/provider/zfs_acl/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/zfs_acl/solaris.rb
+++ b/lib/puppet/provider/zfs_acl/solaris.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:zfs_acl).provide(:solaris) do
   Ace = Puppet::Type::ZfsAcl::Ace
   desc "Provider for management of ZFS ACLs for Oracle Solaris"
   confine :operatingsystem => [:solaris]
-  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11']
   commands :chmod => '/usr/bin/chmod', :ls => '/usr/bin/ls'
 
   mk_resource_methods

--- a/lib/puppet/provider/zone/solaris.rb
+++ b/lib/puppet/provider/zone/solaris.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/puppet/provider/zone/solaris.rb
+++ b/lib/puppet/provider/zone/solaris.rb
@@ -122,7 +122,7 @@ Puppet::Type.type(:zone).provide(:solaris) do
 
 
   def install(dummy_argument=:work_arround_for_ruby_GC_bug)
-    if ['5.11', '5.12'].include? Facter.value(:kernelrelease)
+    if ['5.11'].include? Facter.value(:kernelrelease)
       if !@resource[:install_args] and @resource[:config_profile]
         @resource[:install_args] = " -c " + @resource[:config_profile]
       elsif !@resource[:install_args] and @resource[:archive]

--- a/lib/puppet_x/oracle/solaris_providers/util/svcs.rb
+++ b/lib/puppet_x/oracle/solaris_providers/util/svcs.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2106, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2020, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ module PuppetX::Oracle::SolarisProviders::Util::Svcs
 
   def svcs_escape(value=self)
     if value.kind_of? String
-      value.gsub(/([;&()|^<>\n \t\\\"\'`~*\[\]\$\!])/, '\\\\\1')
+      value.gsub(/([;|^<>\n\t\\\"\'`~\[\]\$\!])/, '\\\\\1')
     else
       value
     end

--- a/lib/puppet_x/oracle/solaris_providers/util/svcs.rb
+++ b/lib/puppet_x/oracle/solaris_providers/util/svcs.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2020, Oracle and/or its affiliates.
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/puppet/provider/nsswitch/solaris_spec.rb
+++ b/spec/unit/puppet/provider/nsswitch/solaris_spec.rb
@@ -106,7 +106,7 @@ describe Puppet::Type.type(:nsswitch).provider(:solaris) do
     it "sets complex value" do
       described_class.expects(:svccfg).with(
         '-s', Nsswitch_fmri, "setprop",
-        "config/#{thing}=files\\ dns:\\[notfound=return\\]")
+        "config/#{thing}=files dns:\\[notfound=return\\]")
       expect(provider.send("#{thing}=".intern,"files dns:[notfound=return]")).
         to eq('files dns:[notfound=return]')
     end

--- a/spec/unit/puppet/provider/svccfg/solaris_spec.rb
+++ b/spec/unit/puppet/provider/svccfg/solaris_spec.rb
@@ -349,9 +349,9 @@ describe Puppet::Type.type(:svccfg).provider(:solaris) do
       end
 
       {
-        %q(simple string) => %q(simple\\ string),
-        %q(it's less simple) => %q(it\\'s\\ less\\ simple),
-        %q(echo foo > /etc/shadow) => %q(echo\\ foo\\ \\>\\ /etc/shadow)
+        %q(simple string) => %q(simple string),
+        %q(it's less simple) => %q(it\\'s less simple),
+        %q(echo foo > /etc/shadow) => %q(echo foo \\> /etc/shadow)
       }.each_pair { |k,v|
         it "escapes shell characters in strings" do
           params[:type] = :astring


### PR DESCRIPTION
This code push is to merge bug fixes from Solaris IPS package to upstream code.
The following bugs are merged:

28036887 solaris_providers/README.md mentions Solaris 12
28625119 Puppet ldap resource does create wrong escapes for service_search_descriptor
27615088 oracle-solaris_providers should drop reference to solaris 5.12
pkg_publisher empty origin fix

After merging the code change for "28625119 Puppet ldap resource does create wrong escapes for service_search_descriptor", two tests from the test suite failed. The reason for this is, the fix for 28625119, removes the code the substitutes " "(space character), with "\\" (double slash).  The test case code should also be modified to change the expected output. 

Here is a sample output of test case failure:
<sniip>
        expected: "simple\\ string"
             got: "simple string"

  24) Puppet::Type::Svccfg::ProviderSolaris#create input munging escapes shell characters in strings
      Failure/Error: expect(provider.to_svcs(k)).to eq(v)

        expected: "it\\'s\\ less\\ simple"
             got: "it\\'s less simple"

        (compared using ==)
      # ./spec/unit/puppet/provider/svccfg/solaris_spec.rb:359:in `block (5 levels) in <top (required)>'

  25) Puppet::Type::Svccfg::ProviderSolaris#create input munging escapes shell characters in strings
      Failure/Error: expect(provider.to_svcs(k)).to eq(v)

        expected: "echo\\ foo\\ \\>\\ /etc/shadow"
             got: "echo foo \\> /etc/shadow"

Changes to **spec/unit/puppet/provider/nsswitch/solaris_spec.rb** and **spec/unit/puppet/provider/svccfg/solaris_spec.rb**, correspond to fixing the above failure.

28036887 and 27615088 refer to removing references to 5.12 in README.md and files in docs, lib directories respectively.

After merging the code changes, ran the test suite. All the tests passed:

# bundle exec rake spec
I, [2021-06-26T12:01:09.775416 #18526]  INFO -- : Creating symlink from spec/fixtures/modules/solaris_providers to /scratch/swdevula/puppet-github-patch_fixes/oracle/puppet-solaris_providers
Cloning into 'spec/fixtures/modules/stdlib'...
remote: Enumerating objects: 565, done.
remote: Counting objects: 100% (565/565), done.
remote: Compressing objects: 100% (529/529), done.
Receiving objects:  84% (475/565)remote: Total 565 (delta 147), reused 114 (delta 11), pack-reused 0
Receiving objects: 100% (565/565), 358.98 KiB | 9.70 MiB/s, done.
Resolving deltas: 100% (147/147), done.
/usr/ruby/2.6/bin/ruby -I/scratch/swdevula/puppet-github-patch_fixes/oracle/puppet-solaris_providers/vendor/cache/ruby/2.6.0/gems/rspec-core-3.10.1/lib:/scratch/swdevula/puppet-github-patch_fixes/oracle/puppet-solaris_providers/vendor/cache/ruby/2.6.0/gems/rspec-support-3.10.2/lib /scratch/swdevula/puppet-github-patch_fixes/oracle/puppet-solaris_providers/vendor/cache/ruby/2.6.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec/\{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit\}/\*\*/\*_spec.rb
.........................................................................................................................................................................................................................................................................................................................................................................*.......................................................................................................................................................................................................................................................................................................**.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Puppet::Type::Nsswitch::ProviderSolaris verify alias processing it fails in puppet 3.6.2 spec tests
     # Temporarily skipped with xit
     # ./spec/unit/puppet/provider/nsswitch/solaris_spec.rb:97

  2) Puppet::Type::Svccfg::ProviderSolaris#delcust should delcust
     # Not yet implemented
     # ./spec/unit/puppet/provider/svccfg/solaris_spec.rb:430

  3) Puppet::Type::Svccfg::ProviderSolaris#delcust should delcust property
     # Not yet implemented
     # ./spec/unit/puppet/provider/svccfg/solaris_spec.rb:431


Deprecation Warnings:

puppetlabs_spec_helper: defaults `mock_with` to `:mocha`. See https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with to choose a sensible value for you


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 1 minute 11.7 seconds (files took 6.38 seconds to load)
2192 examples, 0 failures, 3 pending
