### PR TITLE
Fix `title patterns that use procs are not supported`

### DIFF
--- a/lib/puppet/type/ilb_server.rb
+++ b/lib/puppet/type/ilb_server.rb
@@ -35,9 +35,9 @@ Puppet::Type.newtype(:ilb_server) do
 
   def self.title_patterns
     [
-      [%r((^(.+)\|(.+)\|(.+))$),[:name,:servergroup,:server,:port]],
-      [%r((^(.+)\|(.+))$),[:name,:servergroup,:server]],
-      [%r(.+),[:name]]
+      [%r((^(.+)\|(.+)\|(.+))$),[[:name],[:servergroup],[:server],[:port]]],
+      [%r((^(.+)\|(.+))$),[[:name],[:servergroup],[:server]]],
+      [%r(.+),[[:name]]]
     ]
   end
 


### PR DESCRIPTION
This fixes the `title patterns that use procs are not supported` error when running `puppet generate types`.

Not sure if it should have worked before, but title patterns were incorrectly specified in this type.

See
https://github.com/puppetlabs/puppet-specifications/blob/master/language/resource_types.md#title-patterns

as well as other types using `title_patterns` in this module. eg.
https://github.com/oracle/puppet-solaris_providers/blob/97b9d898c4bb2757145372185f3c97c0a043b280/lib/puppet/type/svccfg.rb#L42

Tests
https://github.com/oracle/puppet-solaris_providers/blob/97b9d898c4bb2757145372185f3c97c0a043b280/spec/unit/puppet/type/ilb_server_spec.rb#L35-L71 still pass.