### PR TITLE
Fix pkg_publisher URI validation

### DIFF
--- a/lib/puppet/type/pkg_publisher.rb
+++ b/lib/puppet/type/pkg_publisher.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2026, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ Puppet::Type.newtype(:pkg_publisher) do
       @should
     end
 
-    newvalues(%r([file|http|https]://.*),:absent)
+    newvalues(%r{\A(?:file|http|https)://.+\z},:absent)
 
     # for origins with a file:// URI, strip any trailing / character
     munge do |value|
@@ -134,7 +134,7 @@ Puppet::Type.newtype(:pkg_publisher) do
   newproperty(:mirror, :array_matching => :all ) do
     desc "Which mirror URI(s) to set.  For multiple mirrors, specify them
               as a list"
-    newvalues(%r([file|http|https]://.*),:absent)
+    newvalues(%r{\A(?:file|http|https)://.+\z},:absent)
     def should
       @should
     end

--- a/spec/unit/puppet/type/pkg_publisher_spec.rb
+++ b/spec/unit/puppet/type/pkg_publisher_spec.rb
@@ -64,7 +64,7 @@ describe Puppet::Type.type(:pkg_publisher) do
           end
         end
         context "rejects" do
-          %w(bare_string).each do |thing|
+          %w(bare_string p://foo nohttp://foo http://).each do |thing|
             it thing.inspect do
               params[type] = thing
               expect { resource }.to raise_error(Puppet::Error, error_pattern)


### PR DESCRIPTION
The original regexes used a character class rather than a list of alternatives. Invalid schemes such as `p://` could pass validation.

This change also anchors it so schemes such as `nohttp://pkg.oracle.com/solaris/release` or `http://` no longer pass either.

I also this with the following POC codex generated for me:
```ruby
# frozen_string_literal: true

before = %r([file|http|https]://.*)
after = %r{\A(?:file|http|https)://.+\z}

cases = [
  'http://pkg.oracle.com/solaris/release',
  'https://pkg.oracle.com/solaris/support',
  'file:///media/solaris-repo',
  'h://not-a-valid-publisher-uri',
  '|://not-a-valid-publisher-uri',
  'prefix-http://embedded-uri',
  'http://'
]

puts "Before fix: #{before.inspect}"
puts "After fix:  #{after.inspect}"
puts
puts "%-40s %-12s %-12s" % ['value', 'before fix', 'after fix']
puts '-' * 64

cases.each do |value|
  before_actual = before.match?(value)
  after_actual = after.match?(value)

  puts "%-40s %-12s %-12s" % [value, before_actual, after_actual]
end
```
with results looking like this:
```
Before fix: /[file|http|https]:\/\/.*/
After fix:  /\A(?:file|http|https):\/\/.+\z/

value                                    before fix   after fix
----------------------------------------------------------------
http://pkg.oracle.com/solaris/release    true         true
https://pkg.oracle.com/solaris/support   true         true
file:///media/solaris-repo               true         true
h://not-a-valid-publisher-uri            true         false
|://not-a-valid-publisher-uri            true         false
prefix-http://embedded-uri               true         false
http://                                  true         false
```

Assisted-By: Codex GPT 5.5