### PR TITLE
fix av_quarantined ignore flag

### DIFF
--- a/lib/puppet/type/system_attributes.rb
+++ b/lib/puppet/type/system_attributes.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2026, Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ Puppet::Type.newtype(:system_attributes) do
     desc "Anti-virus software sets to mark a file as quarantined."
     newvalues(/yes/i,/no/i)
     def insync?(is)
-      if @resource[:ignore_av_modified] == 'true'
+      if @resource[:ignore_av_quarantined] == 'true'
         debug "Ignoring difference in av_quarantined"
         return true if should == :absent
       end


### PR DESCRIPTION
The `'av_quarantined'` property checked `ignore_av_modified` rather than `ignore_av_quarantined`. Check the matching ignore parameter instead.

Assisted-By: Codex GPT 5.5