### PR TITLE
fix issues with the test suite and zfs_acl type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,25 +1,32 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-group(:development, :test) do
-  gem 'metadata-json-lint'
+group(:development) do
   gem 'puppet-blacksmith'
-  gem 'puppetlabs_spec_helper', :require => true
-  gem 'rspec-puppet', :require => true
-  gem 'rspec', :require => false
-  gem 'rake', '>= 13.4.2', :require => false
   gem 'pry', :require => false
   gem 'pry-rescue', :require => false
   gem 'pry-stack_explorer', :require => false
-  gem 'psych', :require => false
-  gem 'puppet', '7.27.0', :require => true
-  gem 'ffi', :require => false
-  gem 'pkg-config', :require => false
-  gem 'semantic_puppet'
+  # Code style
+  gem 'rubocop', '>= 0.49.0', :platforms => [:ruby]
   # Docs
   gem 'puppet-strings'
   gem 'redcarpet'
 end
 
-gem "rubocop", ">= 0.49.0", :platforms => [:ruby]
-gem 'beaker', '~> 2.0', :require => false, :group => :acceptance
-gem 'beaker-rspec', '5.6.0', :require => false, :group => :acceptance
+group(:development, :test) do
+  gem 'metadata-json-lint'
+  gem 'puppetlabs_spec_helper', :require => true
+  gem 'rspec-puppet', :require => true
+  gem 'rspec', :require => false
+  gem 'rake', '>= 13.4.2', :require => false
+  gem 'puppet', '7.27.0', :require => true
+  gem 'base64', :require => false
+  gem 'ffi', :require => false
+  gem 'getoptlong', :require => false
+  gem 'racc', :require => false
+  gem 'syslog', :require => false
+end
+
+group(:acceptance, :optional => true) do
+  gem 'beaker', '~> 2.0', :require => false
+  gem 'beaker-rspec', '5.6.0', :require => false
+end

--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,13 @@ group(:development, :test) do
   gem 'puppetlabs_spec_helper', :require => true
   gem 'rspec-puppet', :require => true
   gem 'rspec', :require => false
-  gem 'rake', '>= 12.3.3', :require => false
+  gem 'rake', '>= 13.4.2', :require => false
   gem 'pry', :require => false
   gem 'pry-rescue', :require => false
   gem 'pry-stack_explorer', :require => false
   gem 'psych', :require => false
-  gem 'puppet', '5.5.21', :require => true
+  gem 'puppet', '7.27.0', :require => true
+  gem 'ffi', :require => false
   gem 'pkg-config', :require => false
   gem 'semantic_puppet'
   # Docs

--- a/lib/puppet/type/zfs_acl.rb
+++ b/lib/puppet/type/zfs_acl.rb
@@ -120,11 +120,6 @@ Puppet::Type.newtype(:zfs_acl) do
   end
 
   newproperty(:acl, :array_matching => :all) do
-    def initialize(args)
-      super(args)
-      @ace_valid = Puppet::Type::ZfsAcl::Ace::Util
-    end
-
     def insync?(current)
       # We need to add default perms to @should to keep
       # insync? working as expected
@@ -226,26 +221,27 @@ See chmod(1) NFSv4 ACL Specification for additional details
       fail "perm_type must be defined" unless value['perm_type']
 
       # Check target value
-      unless @ace_valid.target.include?(value['target']) ||
-             value['target'].match(Regexp.union(@ace_valid.target_patterns))
+      ace_valid = Puppet::Type::ZfsAcl::Ace::Util
+      unless ace_valid.target.include?(value['target']) ||
+             value['target'].match(Regexp.union(ace_valid.target_patterns))
         fail "Invalid target: #{value['target']}"
       end
 
       # Check Permissions
       bad_perms = []
       bad_perms = bad_perms + ([value['perms']].flatten.compact -
-                               @ace_valid.all_perms)
+                               ace_valid.all_perms)
       fail "Invalid perms: #{bad_perms}" unless bad_perms.empty?
 
       # Check Inheritance
       bad_inh = []
       [value['inheritance']].flatten.compact.each do |thing|
-        bad_inh = bad_inh + (value['inheritance'] - @ace_valid.inheritance)
+        bad_inh = bad_inh + (value['inheritance'] - ace_valid.inheritance)
       end
       fail "Invalid Inheritance: #{bad_inh}" unless bad_inh.empty?
 
       # Check perm_type
-      unless @ace_valid.perm_type.include?(value['perm_type'])
+      unless ace_valid.perm_type.include?(value['perm_type'])
         fail "Invalid perm_type: #{value['perm_type']}"
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'facter'
 require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,12 +12,14 @@ RSpec.configure do |config|
   config.mock_with :mocha
   config.example_status_persistence_file_path = 'spec/examples.txt'
 
-  # Resolve and cache provider-selection facts before specs install strict
-  # FileTest stubs for Solaris binaries. Otherwise, Facter may check its own
-  # fact files after those stubs are active, causing failures.
+  # Facter 4 may resolve provider-selection facts after specs install strict
+  # FileTest stubs for Solaris binaries. Resolve and cache those facts first so
+  # Facter does not inspect its own fact files while the stubs are active.
   config.before(:suite) do
-    %i[operatingsystem osfamily kernelrelease].each do |fact|
-      Puppet.runtime[:facter].value(fact)
+    if Gem::Version.new(Facter.version) >= Gem::Version.new('4.0.0')
+      %i[operatingsystem osfamily kernelrelease].each do |fact|
+        Puppet.runtime[:facter].value(fact)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,15 @@ end
 RSpec.configure do |config|
   config.mock_with :mocha
   config.example_status_persistence_file_path = 'spec/examples.txt'
+
+  # Resolve and cache provider-selection facts before specs install strict
+  # FileTest stubs for Solaris binaries. Otherwise, Facter may check its own
+  # fact files after those stubs are active, causing failures.
+  config.before(:suite) do
+    %i[operatingsystem osfamily kernelrelease].each do |fact|
+      Puppet.runtime[:facter].value(fact)
+    end
+  end
 end
 
 include Mocha::API


### PR DESCRIPTION
The test suite needs some love.

There is one fix to the spec helper (Facter 4 looking for files during the test execution breaks when stubs are active), one fix to the ruby itself (`Puppet::Parameter#initialize` signature has changed in Puppet 7), and cleanup/refresh to the `Gemfile`.